### PR TITLE
:bug: 5.008: fix: altera a estrutura dos childrens de CardHeader no c…

### DIFF
--- a/components/cards/box-register.tsx
+++ b/components/cards/box-register.tsx
@@ -1,40 +1,33 @@
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
-import { Social } from '../auth/social';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { Social } from '../auth/social'
 
 interface CardWrapperProps {
-    headerTitle: React.ReactNode;
-    headerSubtitle: React.ReactNode;
-    formComponent: React.ReactNode;
-    showSocial: boolean;
-    footer: React.ReactNode;
+  headerTitle: React.ReactNode
+  headerSubtitle: React.ReactNode
+  formComponent: React.ReactNode
+  showSocial: boolean
+  footer: React.ReactNode
 }
 
 export const BoxRegister: React.FC<CardWrapperProps> = ({
-    headerTitle,
-    headerSubtitle,
-    formComponent,
-    showSocial,
-    footer,
+  headerTitle,
+  headerSubtitle,
+  formComponent,
+  showSocial,
+  footer,
 }) => {
-
-    return (
-        <Card className="bg-[#131313] bg-opacity-85 text-[#FFFEEE] w-[95%] md:w-[30rem] h-fit rounded-lg flex flex-col py-8 backdrop-blur-lg">
-            <CardHeader>
-                <div>
-                    <h1 className='pb-2'>{headerTitle}</h1>
-                    <p>{headerSubtitle}</p>
-                </div>
-            </CardHeader>
-            <CardContent className="w-full flex justify-center items-center">
-                {formComponent}
-            </CardContent>
-            {showSocial && (
-                <Social />
-            )}
-            <CardFooter>
-                {footer}
-            </CardFooter>
-
-        </Card>
-    )
+  return (
+    <Card className="flex h-fit w-[95%] flex-col rounded-lg bg-[#131313] bg-opacity-85 py-8 text-[#FFFEEE] backdrop-blur-lg md:w-[30rem]">
+      <CardHeader>
+        {headerTitle}
+        {headerSubtitle}
+      </CardHeader>
+      <CardContent className="flex w-full items-center justify-center">
+        {/* esse componente aqui poderia ser recebido como children */}
+        {formComponent}
+      </CardContent>
+      {showSocial && <Social />}
+      <CardFooter>{footer}</CardFooter>
+    </Card>
+  )
 }


### PR DESCRIPTION
componente BoxRegister. Era esse envelopamento de h1 em h1 (headerTitle recebe já uma h1) que estava por algum motivo causando aqueles erros. deixei como sugestão receber elemento form, que é o ponto central do componente, como children ao invés de props.
era:
`    
    <CardHeader>
      <div>
          <h1 className='pb-2'>{headerTitle}</h1>
          <p>{headerSubtitle}</p>
      </div>
`
fica sendo:
`
      <CardHeader>
        {headerTitle}
        {headerSubtitle}
      </CardHeader>
`